### PR TITLE
Add VSCode launch configs + organise Wrangler config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Wrangler",
+      "type": "node",
+      "request": "launch",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
+      "program": "${workspaceFolder}/node_modules/wrangler/bin/wrangler.js",
+      "args": ["dev", "--inspector-port=59201"],
+      "attachSimplePort": 59201,
+      "internalConsoleOptions": "neverOpen",
+      "console": "integratedTerminal",
+      "autoAttachChildProcesses": false
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qk_service_template",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --env dev --port 8787",
+    "dev": "wrangler dev src/index.ts --env dev --port 8788",
     "deploy": "wrangler deploy --minify src/index.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "qk_service_template",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --env dev --port 8788",
-    "deploy": "wrangler deploy --minify src/index.ts"
+    "dev": "wrangler dev --env dev",
+    "deploy": "wrangler deploy --minify"
   },
   "dependencies": {
     "@hono/swagger-ui": "^0.4.1",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,15 +1,19 @@
 name = "qk_core_service"
-compatibility_date = "2024-08-22"
-node_compat = true
+main = "src/index.ts"
 
-routes = [
-    { pattern = "api.questkeeper.app/v1/core*", zone_name = "questkeeper.app" },
-]
+compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-09-23"
 
-# Add a binding to call other worker
-services = [
-  { binding = "TASK_COMPLETE_SERVICE", service = "qk_social_service" }
-]
+[dev]
+port = 8788
+
+[[routes]]
+pattern = "api.questkeeper.app/v1/core*"
+zone_name = "questkeeper.app"
+
+[[services]]
+binding = "TASK_COMPLETE_SERVICE"
+service = "qk_social_service"
 
 [vars]
 SUPABASE_URL = "https://mzudaknbrzixjkvjqayw.supabase.co"
@@ -17,5 +21,6 @@ SUPABASE_URL = "https://mzudaknbrzixjkvjqayw.supabase.co"
 [placement]
 mode = "off"
 
-[env.dev]
-vars = { ENVIRONMENT = "dev", SUPABASE_URL = "https://mzudaknbrzixjkvjqayw.supabase.co" }
+[env.dev.vars]
+ENVIRONMENT = "dev"
+SUPABASE_URL = "https://mzudaknbrzixjkvjqayw.supabase.co"


### PR DESCRIPTION
- Add "Launch Wrangler" launch configuration in `.vscode/launch.json`
  - Attaches VSCode's inspector to Wrangler to allow for better debugging.
- Moves CLI arguments from the `dev` NPM script to `wrangler.toml`
- Formats `wrangler.toml` for readability

## See Also
- [questkeeper/microservices-dev](https://github.com/questkeeper/microservices-dev)
- questkeeper/qk_core_service#3
- questkeeper/qk_social_service#3
- questkeeper/qk_notifications_service#3